### PR TITLE
Add basic CRM policy management

### DIFF
--- a/app/policies/page.tsx
+++ b/app/policies/page.tsx
@@ -1,0 +1,13 @@
+import PolicyManager from '@/components/policy-manager'
+import SidebarLayout from '@/components/sidebar-layout'
+
+export default function PoliciesPage() {
+  return (
+    <SidebarLayout>
+      <div className="p-8 text-white space-y-6">
+        <h1 className="text-2xl font-bold">Policies</h1>
+        <PolicyManager />
+      </div>
+    </SidebarLayout>
+  )
+}

--- a/components/policy-manager.tsx
+++ b/components/policy-manager.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useState, ChangeEvent, FormEvent } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+
+interface Policy {
+  id: number
+  customer: string
+  number: string
+  type: string
+  premium: string
+}
+
+const emptyPolicy = { customer: '', number: '', type: '', premium: '' }
+
+export default function PolicyManager() {
+  const [policies, setPolicies] = useState<Policy[]>([])
+  const [form, setForm] = useState<typeof emptyPolicy>(emptyPolicy)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('policies')
+    if (stored) {
+      setPolicies(JSON.parse(stored))
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('policies', JSON.stringify(policies))
+  }, [policies])
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const addPolicy = (e: FormEvent) => {
+    e.preventDefault()
+    if (!form.customer || !form.number) return
+    setPolicies([...policies, { id: Date.now(), ...form }])
+    setForm(emptyPolicy)
+  }
+
+  const removePolicy = (id: number) => {
+    setPolicies(policies.filter((p) => p.id !== id))
+  }
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={addPolicy} className="grid gap-2 md:grid-cols-5">
+        <Input
+          name="customer"
+          value={form.customer}
+          onChange={handleChange}
+          placeholder="Customer"
+        />
+        <Input
+          name="number"
+          value={form.number}
+          onChange={handleChange}
+          placeholder="Policy #"
+        />
+        <Input
+          name="type"
+          value={form.type}
+          onChange={handleChange}
+          placeholder="Type"
+        />
+        <Input
+          name="premium"
+          value={form.premium}
+          onChange={handleChange}
+          placeholder="Premium"
+        />
+        <Button type="submit">Add Policy</Button>
+      </form>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Customer</TableHead>
+            <TableHead>Policy #</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Premium</TableHead>
+            <TableHead className="w-24"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {policies.map((p) => (
+            <TableRow key={p.id}>
+              <TableCell>{p.customer}</TableCell>
+              <TableCell>{p.number}</TableCell>
+              <TableCell>{p.type}</TableCell>
+              <TableCell>{p.premium}</TableCell>
+              <TableCell>
+                <Button size="sm" variant="ghost" onClick={() => removePolicy(p.id)}>
+                  Delete
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/components/sidebar-layout.tsx
+++ b/components/sidebar-layout.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Link from 'next/link'
+import { LayoutDashboard, LineChart, Globe, Wallet, Box, LifeBuoy, Settings } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { PropsWithChildren } from 'react'
+
+export default function SidebarLayout({ children }: PropsWithChildren) {
+  return (
+    <div className="flex h-screen bg-black text-white">
+      <div className="w-64 border-r border-gray-800 p-4">
+        <div className="flex items-center gap-2 mb-8">
+          <Box className="h-6 w-6" />
+          <h1 className="text-xl font-semibold">Vaultify</h1>
+        </div>
+        <div className="space-y-1">
+          <Button asChild variant="ghost" className="w-full justify-start">
+            <Link href="/">
+              <LayoutDashboard className="mr-2 h-4 w-4" />
+              Dashboard
+            </Link>
+          </Button>
+          <Button variant="ghost" className="w-full justify-start">
+            <LineChart className="mr-2 h-4 w-4" />
+            Statistics & Income
+          </Button>
+          <Button variant="ghost" className="w-full justify-start">
+            <Globe className="mr-2 h-4 w-4" />
+            Market
+          </Button>
+          <Button variant="ghost" className="w-full justify-start">
+            <Wallet className="mr-2 h-4 w-4" />
+            Funding
+          </Button>
+          <Button variant="ghost" className="w-full justify-start">
+            <Box className="mr-2 h-4 w-4" />
+            Yield Vaults
+          </Button>
+          <Button asChild variant="ghost" className="w-full justify-start">
+            <Link href="/policies">
+              <Box className="mr-2 h-4 w-4" />
+              Policies
+            </Link>
+          </Button>
+          <Button variant="ghost" className="w-full justify-start">
+            <LifeBuoy className="mr-2 h-4 w-4" />
+            Support
+          </Button>
+          <Button variant="ghost" className="w-full justify-start">
+            <Settings className="mr-2 h-4 w-4" />
+            Settings
+          </Button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-auto">{children}</div>
+    </div>
+  )
+}

--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -1,53 +1,11 @@
-import { LayoutDashboard, LineChart, Globe, Wallet, Box, LifeBuoy, Settings } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import SidebarLayout from "@/components/sidebar-layout"
 
 export default function Dashboard() {
   return (
-    <div className="flex h-screen bg-black text-white">
-      {/* Sidebar */}
-      <div className="w-64 border-r border-gray-800 p-4">
-        <div className="flex items-center gap-2 mb-8">
-          <Box className="h-6 w-6" />
-          <h1 className="text-xl font-semibold">Vaultify</h1>
-        </div>
-
-        <div className="space-y-1">
-          <Button variant="ghost" className="w-full justify-start">
-            <LayoutDashboard className="mr-2 h-4 w-4" />
-            Dashboard
-          </Button>
-          <Button variant="ghost" className="w-full justify-start">
-            <LineChart className="mr-2 h-4 w-4" />
-            Statistics & Income
-          </Button>
-          <Button variant="ghost" className="w-full justify-start">
-            <Globe className="mr-2 h-4 w-4" />
-            Market
-          </Button>
-          <Button variant="ghost" className="w-full justify-start">
-            <Wallet className="mr-2 h-4 w-4" />
-            Funding
-          </Button>
-          <Button variant="ghost" className="w-full justify-start">
-            <Box className="mr-2 h-4 w-4" />
-            Yield Vaults
-          </Button>
-          <Button variant="ghost" className="w-full justify-start">
-            <LifeBuoy className="mr-2 h-4 w-4" />
-            Support
-          </Button>
-          <Button variant="ghost" className="w-full justify-start">
-            <Settings className="mr-2 h-4 w-4" />
-            Settings
-          </Button>
-        </div>
-      </div>
-
-      {/* Main Content */}
-      <div className="flex-1 overflow-auto">
-        <div className="p-8">
+    <SidebarLayout>
+      <div className="p-8 text-white">
           {/* Header */}
           <div className="flex justify-between items-center mb-8">
             <div>
@@ -123,8 +81,7 @@ export default function Dashboard() {
             ))}
           </div>
         </div>
-      </div>
-    </div>
+      </SidebarLayout>
   )
 }
 


### PR DESCRIPTION
## Summary
- create a shared sidebar layout for pages
- implement a simple policy manager with local storage
- add policies page using the new components
- refactor dashboard to use the sidebar layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684227eaf424832fa8e4eef96fa31cc5